### PR TITLE
Handle missing query in graph state

### DIFF
--- a/rag/graph.py
+++ b/rag/graph.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Dict, Any
 from langgraph.graph import StateGraph, END
 from langchain_core.messages import HumanMessage, SystemMessage
 from config.models import LLMAdapter, LLMConfig
@@ -10,8 +9,24 @@ adapter = LLMAdapter(LLMConfig(C.PROVIDER, C.GENERATION_MODEL, C.EMBED_MODEL))
 class AgentState(dict):
     pass
 
+def _hydrate_state(state: AgentState) -> str:
+    """Ensure required fields are present regardless of langgraph input format."""
+    if "query" not in state or "hits" not in state:
+        incoming = state.get("input")
+        if isinstance(incoming, dict):
+            state.setdefault("query", incoming.get("query"))
+            state.setdefault("hits", incoming.get("hits", []))
+
+    q = state.get("query")
+    if q is None:
+        raise ValueError("Missing 'query' in agent state")
+
+    state.setdefault("hits", [])
+    return q
+
+
 def node_analyze(state: AgentState):
-    q = state["query"]
+    q = _hydrate_state(state)
     sys = "Classify user intent (qa/list/count) and propose a short rewritten query for retrieval. Return as JSON with fields: intent, rewritten."
     msg = adapter._chat.invoke([("system", sys), ("user", q)])
     state.update({"rewritten": msg.content})
@@ -20,9 +35,10 @@ def node_analyze(state: AgentState):
 # retrieval is done by Server1 via HTTP; here we assume injected results in state["hits"]
 
 def node_generate(state: AgentState):
+    q = _hydrate_state(state)
     context = "\n\n".join([h["text"] for h in state.get("hits", [])])
     sys = "You are a strict RAG assistant. Answer ONLY from Context. If missing, say 'Không tìm thấy trong tài liệu'. For list/count, double-check numbers from context."
-    user = f"Context:\n{context}\n\nQuestion: {state['query']}"
+    user = f"Context:\n{context}\n\nQuestion: {q}"
     msg = adapter._chat.invoke([("system", sys), ("user", user)])
     state["answer"] = msg.content
     return state


### PR DESCRIPTION
## Summary
- normalize the state passed to the LangGraph nodes so the query and hits are always populated
- reuse the normalized query in both analyze and generate nodes to avoid KeyErrors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deae8b8c60833394277f768d3de380